### PR TITLE
relayout settings

### DIFF
--- a/Recorder/ui/SettingsPage.qml
+++ b/Recorder/ui/SettingsPage.qml
@@ -144,7 +144,8 @@ Page {
             left: parent.left
             right: parent.right
         }
-        contentHeight: column.height
+        flickableDirection: Flickable.AutoFlickIfNeeded
+        contentHeight: column.childrenRect.height
 
         Column {
             id: column

--- a/Recorder/ui/SettingsPage.qml
+++ b/Recorder/ui/SettingsPage.qml
@@ -254,13 +254,11 @@ Page {
                     id: gQualityLayout
                     title.text: i18n.tr("Record Quality")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.qualityData, settings.encodingQuality)
+                    subtitle.color: UbuntuColors.porcelain
 
-                    ProgressionSlot { color: "white" }
+                    ProgressionSlot { color: "white"}
 
-                    Label {
-                        text: recorder.getDataName(recorder.qualityData, settings.encodingQuality)
-                        color: UbuntuColors.porcelain
-                    }
                 }
 
             }
@@ -295,13 +293,11 @@ Page {
 
                     title.text: i18n.tr("Audio Codec")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.codecData, settings.audioCodec)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.codecData, settings.audioCodec)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }
 
@@ -331,13 +327,11 @@ Page {
 
                     title.text: i18n.tr("File Container")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.containerData, settings.fileContainer)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.containerData, settings.fileContainer)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }*/
 
@@ -364,13 +358,11 @@ Page {
                     // TRANSLATORS: The count of sound channel
                     title.text: i18n.tr("Channels")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.channelData, settings.channels)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.channelData, settings.channels)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }
 
@@ -398,13 +390,11 @@ Page {
 
                     title.text: i18n.tr("Encoding Mode")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.encodingModeData, settings.encodingMode)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.encodingModeData, settings.encodingMode)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }
 
@@ -432,13 +422,11 @@ Page {
 
                     title.text: i18n.tr("Encoding Quality")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.qualityData, settings.encodingQuality)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.qualityData, settings.encodingQuality)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }
 
@@ -466,13 +454,11 @@ Page {
 
                     title.text: i18n.tr("Bitrate")
                     title.color: "white"
+                    subtitle.text: recorder.getDataName(recorder.bitrateData, settings.bitrate)
+                    subtitle.color: UbuntuColors.porcelain
 
                     ProgressionSlot { color: "white" }
 
-                    Label {
-                        text: recorder.getDataName(recorder.bitrateData, settings.bitrate)
-                        color: UbuntuColors.porcelain
-                    }
                 }
             }
         }


### PR DESCRIPTION
1. make settings page flickable if needed, otherwise some items are inaccessible in landscape mode
2. move current set value to subtitle instead of label, so they can always be read in full length

![screenshot20200226_222325273](https://user-images.githubusercontent.com/37637312/75391197-e6248a00-58e9-11ea-874e-b485d9259436.png)
